### PR TITLE
ignore css keyframes animation styles

### DIFF
--- a/rule.js
+++ b/rule.js
@@ -69,6 +69,13 @@ module.exports = {
                   // e.g. `{ ...foo }`
                   return;
                 }
+
+                if (property.key.type === 'Literal') {
+                  // Skip literal keys for now.
+                  // e.g. `@keyframes myAnimation: { }`
+                  return;
+                }
+
                 definedClasses[property.key.name] = property;
               });
             }


### PR DESCRIPTION
Hi! Thanks for great rule, i've already clean a lot of unused styles.

But for now css keyframes animation rules parsed incorrectly
e.g.:
```
const useStyles = makeStyles(() => ({ 
  animatedDiv: {
    animation: '$myAnimation 1s linear',
  },
  '@keyframes myAnimation': { },
});
```
causes error "ESLint: Class `undefined` is unused(mui-unused-classes/unused-classes)", which has two problems:
1) We need to look for usage in other styles not in component (also as you see usage started with $ without '@keyframes ' prefix)
2) Class in error has 'undefined' name because '@keyframes myAnimation' is a key with Literal type which doesn't contain key.name property

For now I just add ignore because it blocks the rule usage.