### PR TITLE
Support eslint 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-mui-unused-classes",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "eslint plugin to detect unused material-ui styling classes",
   "main": "index.js",
   "scripts": {
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@typescript-eslint/parser": "^4.9.0",
-    "eslint": "^7.14.0",
+    "eslint": "^7.14.0 || ^8.0.0",
     "mocha": "^8.2.1",
     "typescript": "^4.1.2"
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/jens-ox/eslint-plugin-material-ui-unused-classes#readme",
   "peerDependencies": {
-    "eslint": "^7.14.0"
+    "eslint": "^7.14.0 || ^8.0.0"
   },
   "devDependencies": {
     "@typescript-eslint/parser": "^4.9.0",


### PR DESCRIPTION
Closes https://github.com/jens-ox/eslint-plugin-material-ui-unused-classes/issues/8

This is a PR for the branch mentioned here https://github.com/jens-ox/eslint-plugin-material-ui-unused-classes/issues/8#issuecomment-1025318418, which makes the suggested change to allow eslint 8. 

@jens-ox would you be able to merge this in and release to allow this plugin to be used cleanly with newer versions of eslint as well?